### PR TITLE
Inherit user warm start value when loading problem

### DIFF
--- a/src/algorithm.jl
+++ b/src/algorithm.jl
@@ -266,7 +266,7 @@ function MathProgBase.loadproblem!(m::PODNonlinearModel,
     pick_vars_discretization(m)     # Picking variables to be discretized
     initialize_discretization(m)    # Initialize discretization dictionary
 
-    m.best_sol = fill(NaN, m.num_var_orig)
+    m.best_sol = m.d_orig.m.colVal
 
     logging_summary(m)
 end


### PR DESCRIPTION
Fetch the value from evaluated (NLP) d_orig.m.colVal as the warm start value for local solves.
If a user didn't specify any warm start, it will work as before to fill the warm start vector with NaNs.