### PR TITLE
[PR against moi-wrapper branch] VectorOfVariables-related changes

### DIFF
--- a/src/MOI_wrapper/constraints.jl
+++ b/src/MOI_wrapper/constraints.jl
@@ -42,7 +42,10 @@ macro define_add_constraint(function_type, set_type, array_name)
     quote
         function MOI.add_constraint(model::Optimizer, func::$function_type, set::$set_type)
             check_inbounds(model, func)
-            push!(model.$(array_name), (MOIU.canonical(func), set))
+            if !isa(func, VECTOR) # TODO: MOIU.canonical method for VectorOfVariables?
+                func = MOIU.canonical(func)
+            end
+            push!(model.$(array_name), (func, set))
             return MOI.ConstraintIndex{$function_type, $set_type}(length(model.$(array_name)))
         end
     end

--- a/src/MOI_wrapper/variables.jl
+++ b/src/MOI_wrapper/variables.jl
@@ -30,6 +30,13 @@ function check_inbounds(model::Optimizer, vi::VI)
 	end
 	return
 end
+
+function check_inbounds(model::Optimizer, vec::VECTOR)
+    for vi in vec.variables
+        check_inbounds(model, vi)
+    end
+    return
+end
 	
 check_inbounds(model::Optimizer, var::SVF) = check_inbounds(model, var.variable)
 	


### PR DESCRIPTION
* Add `check_inbounds` method for `VectorOfVariables`. 
* Don't call `canonical` on `VectorOfVariables`. 