### PR TITLE
fix assumption that deep copied 0-field mutable structs compare equal

### DIFF
--- a/src/solver.jl
+++ b/src/solver.jl
@@ -315,7 +315,7 @@ mutable struct AlpineNonlinearModel <: MathProgBase.AbstractNonlinearModel
     end
 end
 
-mutable struct UnsetSolver <: MathProgBase.AbstractMathProgSolver
+struct UnsetSolver <: MathProgBase.AbstractMathProgSolver
 end
 
 const empty_solver = UnsetSolver()


### PR DESCRIPTION
When running the tests for this package on the upcoming 1.3 release I got the error:

```
solverstring = "Alpine.UnsetSolver()"
Partitioning variable selection tests :: nlp3: Error During Test at /root/.julia/packages/Alpine/yThaY/test/solver.jl:18
  Got exception outside of a @test
  Unsupported MINLP local solver Alpine.UnsetSolver(); use a Alpine-supported MINLP local solver
```

I tracked it down to the following issue https://github.com/JuliaLang/julia/issues/33359.

This PR works around the problem.