### PR TITLE
Remove compat on Pkg

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,6 @@ JuMP = "0.22, 0.23, 1"
 Juniper = "0.8, 0.9"
 MathOptInterface = "0.10, 1"
 Pavito = "0.3.4, 0.3.5"
-Pkg = "1.8"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
Stdlibs don't need compat bounds. This was preventing Alpine from being installed on Julia v1.6.