### PR TITLE
Implement DualStatus

### DIFF
--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -155,7 +155,7 @@ function MOI.get(m::Optimizer, attr::MOI.PrimalStatus)
     return MOI.NO_SOLUTION
 end
 
-# MOI.get(::Optimizer, ::MOI.PrimalStatus) = MOI.NO_SOLUTION
+MOI.get(::Optimizer, ::MOI.DualStatus) = MOI.NO_SOLUTION
 
 MOI.get(m::Optimizer, ::MOI.ObjectiveValue) = m.best_obj
 MOI.get(m::Optimizer, ::MOI.ObjectiveBound) = m.best_bound

--- a/test/test_algorithm.jl
+++ b/test/test_algorithm.jl
@@ -220,6 +220,8 @@ end
     m = multi2(solver = test_solver)
     JuMP.optimize!(m)
     @test termination_status(m) == MOI.OPTIMAL
+    @test primal_status(m) == MOI.FEASIBLE_POINT
+    @test dual_status(m) == MOI.NO_SOLUTION
     @test isapprox(objective_value(m), 0.92906489; atol = 1e-3)
 end
 


### PR DESCRIPTION
Otherwise, `JuMP.solution_summary` throws an error
```
ERROR: MathOptInterface.GetAttributeNotAllowed{MathOptInterface.ConstraintDual}
```