### PR TITLE
Implement RawStatusString

### DIFF
--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -134,6 +134,10 @@ function MOI.get(m::Optimizer, ::TightenedUpperBound, vi::MOI.VariableIndex)
     return m.u_var_tight[vi.value]
 end
 
+function MOI.get(m::Optimizer, ::MOI.RawStatusString)
+    return "Alpine ended with status $(m.alpine_status)"
+end
+
 MOI.get(m::Optimizer, ::MOI.TerminationStatus) = m.alpine_status
 
 function MOI.get(m::Optimizer, attr::MOI.PrimalStatus)

--- a/src/log.jl
+++ b/src/log.jl
@@ -257,7 +257,8 @@ function summary_status(m::Optimizer)
         @warn "  [EXCEPTION] Indefinite Alpine status. Please report your instance (& solver configuration) as an issue (https://github.com/lanl-ansi/Alpine.jl/issues) to help us make Alpine better."
     end
 
-    printstyled("\n*** Alpine ended with status $(m.alpine_status) ***\n")
+    raw = MOI.get(m, MOI.RawStatusString())
+    printstyled("\n*** $raw ***\n")
 
     return
 end

--- a/test/test_algorithm.jl
+++ b/test/test_algorithm.jl
@@ -222,6 +222,7 @@ end
     @test termination_status(m) == MOI.OPTIMAL
     @test primal_status(m) == MOI.FEASIBLE_POINT
     @test dual_status(m) == MOI.NO_SOLUTION
+    @test raw_status(m) isa String
     @test isapprox(objective_value(m), 0.92906489; atol = 1e-3)
 end
 


### PR DESCRIPTION
Last remaining piece needed for `JuMP.solution_summary` to work.
The status string could updated to be more custom and not restricted to `MOI.TerminationStatusCode` but I leave it for another PR.
At this this one matches what is printed by the log by construction so when the log is improved, `RawStatusString` will be too