### PR TITLE
Fix failing tests : atol -> rtol

### DIFF
--- a/test/test_algorithm.jl
+++ b/test/test_algorithm.jl
@@ -734,8 +734,8 @@ end
     JuMP.optimize!(m)
 
     @test termination_status(m) == MOI.OPTIMAL
-    @test isapprox(objective_value(m), 3651.020370626844; atol = 1e-4)
-    @test isapprox(objective_bound(m), 3650.786358471944; atol = 1e-4)
+    @test isapprox(objective_value(m), 3651.020370626844; rtol = 1e-4)
+    @test isapprox(objective_bound(m), 3650.786358471944; rtol = 1e-4)
 
     alpine = JuMP.backend(m).optimizer.model
     @test alpine.nonconvex_terms[Expr[:(x[2]), :(x[4])]][:y_idx] == 19


### PR DESCRIPTION
It is currently failing with
```
Algorithm Test with binprod terms: Test Failed at /home/runner/.julia/dev/Alpine/test/test_algorithm.jl:738
  Expression: isapprox(objective_bound(m), 3650.786358471944; atol = 0.0001)
   Evaluated: isapprox(3650.7717897289886, 3650.786358471944; atol = 0.0001)
```
See https://github.com/jump-dev/MathOptInterface.jl/actions/runs/8442608082/job/23124390039