### PR TITLE
Don't erroneously claim support for `Integer` variables

### DIFF
--- a/examples/MINLPs/milp.jl
+++ b/examples/MINLPs/milp.jl
@@ -1,8 +1,0 @@
-function milp(; solver = nothing)
-    m = JuMP.Model(solver)
-
-    @variable(m, 0 <= objvar <= 20, Int)
-    @objective(m, Min, objvar)
-
-    return m
-end

--- a/examples/MINLPs/milp.jl
+++ b/examples/MINLPs/milp.jl
@@ -1,0 +1,8 @@
+function milp(; solver = nothing)
+    m = JuMP.Model(solver)
+
+    @variable(m, 0 <= objvar <= 20, Int)
+    @objective(m, Min, objvar)
+
+    return m
+end

--- a/src/main_algorithm.jl
+++ b/src/main_algorithm.jl
@@ -97,10 +97,6 @@ function load!(m::Optimizer)
     # Populate data to create the bounding MIP model
     recategorize_var(m)             # Initial round of variable re-categorization
 
-    :Int in m.var_type_orig && error(
-        "Alpine does not support MINLPs with generic integer (non-binary) variables yet!",
-    )
-
     # Solver-dependent detection
     _fetch_mip_solver_identifier(m)
     _fetch_nlp_solver_identifier(m)

--- a/test/test_algorithm.jl
+++ b/test/test_algorithm.jl
@@ -1043,3 +1043,14 @@ end
     @test isapprox(objective_value(m), 13; atol = 1e-4)
     @test MOI.get(m, Alpine.NumberOfIterations()) == 0
 end
+
+@testset "Test integer variables" begin
+    test_solver = optimizer_with_attributes(
+        Alpine.Optimizer,
+        "nlp_solver" => IPOPT,
+        "mip_solver" => HIGHS,
+        "minlp_solver" => JUNIPER,
+    )
+    m = milp(solver = test_solver)
+    @test_throws "Alpine does not support MINLPs with generic integer (non-binary) variables yet!" JuMP.optimize!(m)
+end

--- a/test/test_algorithm.jl
+++ b/test/test_algorithm.jl
@@ -1051,20 +1051,16 @@ end
         "mip_solver" => HIGHS,
         "minlp_solver" => JUNIPER,
     )
-
-    m = JuMP.Model(test_solver)
-
-    @variable(m, -10 <= objvar <= 20, Int)
-
-    @objective(m, Min, objvar)
-
-    JuMP.optimize!(m)
-
-    @test termination_status(m) == MOI.OPTIMAL
-    @test isapprox(objective_value(m), -10; atol = 1e-4)
-    @test isapprox(value(objvar), -10, atol = 1E-6)
-    @test MOI.get(m, Alpine.NumberOfIterations()) == 0
+    model = JuMP.Model(test_solver)
+    @variable(model, -10 <= x <= 20, Int)
+    @objective(model, Min, x)
+    JuMP.optimize!(model)
+    @test termination_status(model) == MOI.OPTIMAL
+    @test isapprox(objective_value(model), -10; atol = 1e-4)
+    @test isapprox(value(x), -10, atol = 1e-6)
+    @test MOI.get(model, Alpine.NumberOfIterations()) == 0
 end
+
 @testset "Test integer variable support 0" begin
     test_solver = optimizer_with_attributes(
         Alpine.Optimizer,
@@ -1072,19 +1068,17 @@ end
         "mip_solver" => HIGHS,
         "minlp_solver" => JUNIPER,
     )
-
-    m = JuMP.Model(test_solver)
-
-    @variable(m, objvar, Int)
-    @constraint(m, -10 <= objvar)
-    @constraint(m, objvar <= 20)
-
-    @objective(m, Min, objvar)
-
-    @test_throws "Unable to use IntegerToZeroOneBridge because the variable MOI.VariableIndex(1) has a non-finite domain" JuMP.optimize!(
-        m,
+    model = JuMP.Model(test_solver)
+    @variable(model, x, Int)
+    @objective(model, Min, x)
+    @test_throws(
+        ErrorException(
+            "Unable to use IntegerToZeroOneBridge because the variable MOI.VariableIndex(1) has a non-finite domain",
+        ),
+        JuMP.optimize!(model),
     )
 end
+
 @testset "Test integer variable support 1" begin
     test_solver = optimizer_with_attributes(
         Alpine.Optimizer,
@@ -1092,18 +1086,17 @@ end
         "mip_solver" => HIGHS,
         "minlp_solver" => JUNIPER,
     )
-
-    m = JuMP.Model(test_solver)
-
-    @variable(m, -10 <= objvar, Int)
-    @constraint(m, objvar <= 20)
-
-    @objective(m, Min, objvar)
-
-    @test_throws "Unable to use IntegerToZeroOneBridge because the variable MOI.VariableIndex(1) has a non-finite domain" JuMP.optimize!(
-        m,
+    model = JuMP.Model(test_solver)
+    @variable(model, -10 <= x, Int)
+    @objective(model, Min, x)
+    @test_throws(
+        ErrorException(
+            "Unable to use IntegerToZeroOneBridge because the variable MOI.VariableIndex(1) has a non-finite domain",
+        ),
+        JuMP.optimize!(model),
     )
 end
+
 @testset "Test integer variable support 2" begin
     test_solver = optimizer_with_attributes(
         Alpine.Optimizer,
@@ -1111,15 +1104,13 @@ end
         "mip_solver" => HIGHS,
         "minlp_solver" => JUNIPER,
     )
-
-    m = JuMP.Model(test_solver)
-
-    @variable(m, objvar <= 20, Int)
-    @constraint(m, -10 <= objvar)
-
-    @objective(m, Min, objvar)
-
-    @test_throws "Unable to use IntegerToZeroOneBridge because the variable MOI.VariableIndex(1) has a non-finite domain" JuMP.optimize!(
-        m,
+    model = JuMP.Model(test_solver)
+    @variable(model, x <= 20, Int)
+    @objective(model, Min, x)
+    @test_throws(
+        ErrorException(
+            "Unable to use IntegerToZeroOneBridge because the variable MOI.VariableIndex(1) has a non-finite domain",
+        ),
+        JuMP.optimize!(model),
     )
 end


### PR DESCRIPTION
As discussed in https://github.com/lanl-ansi/Alpine.jl/issues/244,
it is counter-productive for Alpine to declare `Integer` variables to be supported,
only to, then, produce a nice error message. This prevents `IntegerToZeroOneBridge`
from triggering and actually providing transparent support for them..

But that requires adding support at least for
`MOI.is_valid(model::Alpine.Optimizer, ci::MOI.ConstraintIndex{MOI.VariableIndex,S})`
and
`MOI.get(model::Alpine.Optimizer, ::MOI.ConstraintSet, ci::MOI.ConstraintIndex{MOI.VariableIndex,S})`,
but some other pieces seem missing too.

Fixes https://github.com/lanl-ansi/Alpine.jl/issues/244
Refs. https://github.com/lanl-ansi/Alpine.jl/issues/233