### PR TITLE
Remove unnecessary Alp module reference

### DIFF
--- a/src/Alpine.jl
+++ b/src/Alpine.jl
@@ -10,7 +10,6 @@ import Combinatorics
 import Pkg
 
 const ALPINE_DEBUG = false
-const Alp = Alpine
 
 include("const.jl")
 

--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -96,7 +96,7 @@ mutable struct Optimizer <: MOI.AbstractOptimizer
     bound_sol_pool::Dict{Any,Any}                        # A pool of solutions from solving model_mip
 
     # Linking constraints info for Multilinear terms
-    linking_constraints_info::Union{Nothing,Dict{Any,Any}}     # Stored multilinear linking constraints info 
+    linking_constraints_info::Union{Nothing,Dict{Any,Any}}     # Stored multilinear linking constraints info
 
     # Logging information and status
     logs::Dict{Symbol,Any}                          # Logging information
@@ -108,7 +108,7 @@ mutable struct Optimizer <: MOI.AbstractOptimizer
     # Constructor for Alpine.Optimizer
     function Optimizer()
         m = new()
-        m.options = Alp.get_default_options()
+        m.options = get_default_options()
         MOI.empty!(m)
         return m
     end
@@ -254,10 +254,10 @@ MOI.get(::Optimizer, ::MOI.SolverName) = "Alpine"
 MOI.get(::Optimizer, ::MOI.SolverVersion) = _ALPINE_VERSION
 
 function MOI.set(model::Optimizer, param::MOI.RawOptimizerAttribute, value)
-    return Alp.set_option(model, Symbol(param.name), value)
+    return set_option(model, Symbol(param.name), value)
 end
 function MOI.get(model::Optimizer, param::MOI.RawOptimizerAttribute)
-    return Alp.get_option(model, Symbol(param.name))
+    return get_option(model, Symbol(param.name))
 end
 
 function MOI.add_variables(model::Optimizer, n::Int)
@@ -395,10 +395,10 @@ is_max_sense(model::Optimizer) = model.sense_orig == MOI.MAX_SENSE
 
 function MOI.set(model::Optimizer, ::MOI.ObjectiveSense, sense)
     model.sense_orig = sense
-    if Alp.is_max_sense(model)
+    if is_max_sense(model)
         model.best_obj = -Inf
         model.best_bound = Inf
-    elseif Alp.is_min_sense(model)
+    elseif is_min_sense(model)
         model.best_obj = Inf
         model.best_bound = -Inf
     else

--- a/src/embedding.jl
+++ b/src/embedding.jl
@@ -5,14 +5,14 @@
 function embedding_map(λCnt::Int, encoding::Any = ebd_gray, ibs::Bool = false)
     map = Dict()
 
-    encoding = Alp.resolve_encoding_key(encoding)
+    encoding = resolve_encoding_key(encoding)
     L = Int(ceil(log(2, λCnt - 1)))
     for i in 1:L*2
         map[i] = Set()
     end
     H = [encoding(i, L) for i in 0:max(1, (2^L - 1))]
     map[:H_orig] = H
-    map[:H] = [Alp.ebd_support_binary_vec(H[i]) for i in 1:length(H)] # Store the map
+    map[:H] = [ebd_support_binary_vec(H[i]) for i in 1:length(H)] # Store the map
     map[:L] = L
 
     !is_compatible_encoding(H) && error("Encodign method is not SOS-2 compatible...")
@@ -57,7 +57,7 @@ end
 	This function is the same σ() function described in Vielma and Nemhauser 2011.
 """
 function ebd_σ(b::String)
-    sv = Alp.ebd_support_bool_vec(b)
+    sv = ebd_support_bool_vec(b)
     return [i for i in 1:length(sv) if sv[i]]
 end
 
@@ -82,10 +82,7 @@ end
 function is_compatible_encoding(code_seq::Vector)
     for i in 1:(length(code_seq)-1)
         sum(
-            abs.(
-                Alp.ebd_support_bool_vec(code_seq[i]) -
-                Alp.ebd_support_bool_vec(code_seq[i+1])
-            ),
+            abs.(ebd_support_bool_vec(code_seq[i]) - ebd_support_bool_vec(code_seq[i+1])),
         ) != 1 && return false
     end
     return true
@@ -132,8 +129,8 @@ function ebd_link_xα(
 
     # Expression expansion
     for i in 1:P
-        code_vec = Alp.ebd_support_bool_vec(code_seq[i])
-        lifters, exprs = Alp.ebd_link_expression(code_vec, lifters, exprs, i)
+        code_vec = ebd_support_bool_vec(code_seq[i])
+        lifters, exprs = ebd_link_expression(code_vec, lifters, exprs, i)
     end
 
     # Construct Variable Vector
@@ -145,11 +142,7 @@ function ebd_link_xα(
         base_name = "αA$(var_idx)"
     )
     for i in keys(lifters) # Build first-level evaluation
-        Alp.relaxation_multilinear_binary(
-            m.model_mip,
-            α_A[lifters[i]-L],
-            [α[j] for j in i],
-        )
+        relaxation_multilinear_binary(m.model_mip, α_A[lifters[i]-L], [α[j] for j in i])
     end
 
     α_R = [α; α_A] # Initialize/re-arrgange the variable sequence

--- a/src/heuristics.jl
+++ b/src/heuristics.jl
@@ -21,9 +21,9 @@ function update_disc_cont_var(m::Optimizer)
         (var_diffs = _eval_var_diffs!(m.nonconvex_terms, var_diffs))
 
     distance = Dict(zip(var_idxs, var_diffs))
-    Alp.weighted_min_vertex_cover(m, distance)
+    weighted_min_vertex_cover(m, distance)
 
-    (Alp.get_option(m, :log_level) > 100) &&
+    (get_option(m, :log_level) > 100) &&
         println("updated partition var selection => $(m.disc_vars)")
     return
 end

--- a/src/log.jl
+++ b/src/log.jl
@@ -5,7 +5,7 @@ function create_logs!(m)
     # Timers
     logs[:presolve_time] = 0.0                           # Total presolve-time of the algorithm
     logs[:total_time] = 0.0                              # Total run-time of the algorithm
-    logs[:time_left] = Alp.get_option(m, :time_limit)    # Total remaining time of the algorithm if time-out is specified
+    logs[:time_left] = get_option(m, :time_limit)    # Total remaining time of the algorithm if time-out is specified
 
     # Values
     logs[:obj] = []                 # Iteration-based objective
@@ -23,15 +23,15 @@ end
 
 function reset_timer(m::Optimizer)
     m.logs[:total_time] = 0.0
-    m.logs[:time_left] = Alp.get_option(m, :time_limit)
+    m.logs[:time_left] = get_option(m, :time_limit)
     return m
 end
 
 function logging_summary(m::Optimizer)
-    if Alp.get_option(m, :log_level) > 0
+    if get_option(m, :log_level) > 0
         printstyled("\nPROBLEM STATISTICS\n", color = :cyan, bold = true)
-        Alp.is_min_sense(m) && (println("  Objective sense = Min"))
-        Alp.is_max_sense(m) && (println("  Objective sense = Max"))
+        is_min_sense(m) && (println("  Objective sense = Min"))
+        is_max_sense(m) && (println("  Objective sense = Max"))
         println(
             "  # Variables = ",
             length([i for i in 1:m.num_var_orig if m.var_type[i] == :Cont]) +
@@ -45,7 +45,7 @@ function logging_summary(m::Optimizer)
         println("  # Constraints = ", m.num_constr_orig)
         println("  # NL Constraints = ", m.num_nlconstr_orig)
         println("  # Linear Constraints = ", m.num_lconstr_orig)
-        Alp.get_option(m, :recognize_convex) && println(
+        get_option(m, :recognize_convex) && println(
             "  # Detected convex constraints = $(length([i for i in m.constr_structure if i == :convex]))",
         )
         println("  # Detected nonlinear terms = ", length(m.nonconvex_terms))
@@ -56,7 +56,7 @@ function logging_summary(m::Optimizer)
         println("  # Potential variables for partitioning = ", length(m.disc_vars))
 
         printstyled("SUB-SOLVERS USED BY ALPINE\n", color = :cyan, bold = true)
-        if Alp.get_option(m, :minlp_solver) === nothing
+        if get_option(m, :minlp_solver) === nothing
             println("  NLP local solver = ", m.nlp_solver_id)
         else
             println("  MINLP local solver = ", m.minlp_solver_id)
@@ -69,66 +69,59 @@ function logging_summary(m::Optimizer)
             Pkg.TOML.parse(read(string(pkgdir(Alpine), "/Project.toml"), String))["version"],
         )
 
-        if Alp.is_min_sense(m)
+        if is_min_sense(m)
             println(
                 "  Maximum iterations (lower-bounding MIPs) = ",
-                Alp.get_option(m, :max_iter),
+                get_option(m, :max_iter),
             )
-        elseif Alp.is_max_sense(m)
+        elseif is_max_sense(m)
             println(
                 "  Maximum iterations (upper-bounding MIPs) = ",
-                Alp.get_option(m, :max_iter),
+                get_option(m, :max_iter),
             )
         else
-            println(
-                "  Maximum iterations (bounding MIPs) =  ",
-                Alp.get_option(m, :max_iter),
-            )
+            println("  Maximum iterations (bounding MIPs) =  ", get_option(m, :max_iter))
         end
 
-        println(
-            "  Relative global optimality gap = ",
-            Alp.get_option(m, :rel_gap) * 100,
-            "%",
-        )
+        println("  Relative global optimality gap = ", get_option(m, :rel_gap) * 100, "%")
 
-        if Alp.get_option(m, :disc_var_pick) == 0
+        if get_option(m, :disc_var_pick) == 0
             println("  Potential variables chosen for partitioning = All")
-        elseif Alp.get_option(m, :disc_var_pick) == 1
+        elseif get_option(m, :disc_var_pick) == 1
             println(
                 "  Potential variables chosen for partitioning = Minimum vertex cover",
             )
         end
 
-        if Alp.get_option(m, :partition_scaling_factor_branch)
+        if get_option(m, :partition_scaling_factor_branch)
             println("  Partition scaling factor branch activated")
         else
             println(
                 "  Partition scaling factor = ",
-                Alp.get_option(m, :partition_scaling_factor),
+                get_option(m, :partition_scaling_factor),
             )
         end
-        (Alp.get_option(m, :convhull_ebd)) && println("  Using convhull_ebd formulation")
-        (Alp.get_option(m, :convhull_ebd)) &&
-            println("  Encoding method = $(Alp.get_option(m, :convhull_ebd_encode))")
-        (Alp.get_option(m, :convhull_ebd)) && println(
-            "  Independent branching scheme = $(Alp.get_option(m, :convhull_ebd_ibs))",
+        (get_option(m, :convhull_ebd)) && println("  Using convhull_ebd formulation")
+        (get_option(m, :convhull_ebd)) &&
+            println("  Encoding method = $(get_option(m, :convhull_ebd_encode))")
+        (get_option(m, :convhull_ebd)) && println(
+            "  Independent branching scheme = $(get_option(m, :convhull_ebd_ibs))",
         )
-        println("  Bound-tightening presolve = ", Alp.get_option(m, :presolve_bt))
-        Alp.get_option(m, :presolve_bt) && println(
+        println("  Bound-tightening presolve = ", get_option(m, :presolve_bt))
+        get_option(m, :presolve_bt) && println(
             "  Maximum iterations (OBBT) = ",
-            Alp.get_option(m, :presolve_bt_max_iter),
+            get_option(m, :presolve_bt_max_iter),
         )
     end
 end
 
 function logging_head(m::Optimizer)
-    if Alp.is_min_sense(m)
+    if is_min_sense(m)
         printstyled("LOWER-BOUNDING ITERATIONS", color = :cyan, bold = true)
         UB_iter = "Incumbent"
         UB = "Best Incumbent"
         LB = "Lower Bound"
-    elseif Alp.is_max_sense(m)
+    elseif is_max_sense(m)
         printstyled("UPPER-BOUNDING ITERATIONS", color = :cyan, bold = true)
         UB_iter = "Incumbent"
         UB = "Best Incumbent"
@@ -246,7 +239,7 @@ function summary_status(m::Optimizer)
 
     if m.detected_bound && m.detected_incumbent
         m.alpine_status =
-            m.best_rel_gap > Alp.get_option(m, :rel_gap) ? MOI.OTHER_LIMIT : MOI.OPTIMAL
+            m.best_rel_gap > get_option(m, :rel_gap) ? MOI.OTHER_LIMIT : MOI.OPTIMAL
     elseif m.status[:bounding_solve] == MOI.INFEASIBLE
         m.alpine_status = MOI.INFEASIBLE
     elseif m.detected_bound && !m.detected_incumbent
@@ -269,11 +262,11 @@ end
 #     cnt = length([1 for j in keys(m.nonconvex_terms) if m.nonconvex_terms[j][:nonlinear_type] == i])
 #     cnt > 0 && println("\tTerm $(i) Count = $(cnt) ")
 # end
-# println("  Maximum solution time = ", Alp.get_option(m, :time_limit))
-# println("  Basic bound propagation = ", Alp.get_option(m, :presolve_bp))
-# println("  Conseuctive solution rejection = after ", Alp.get_option(m, :disc_consecutive_forbid), " times")
-# Alp.get_option(m, :presolve_bt) && println("bound tightening presolve algorithm = ", Alp.get_option(m, :presolve_bt)_algo)
-# Alp.get_option(m, :presolve_bt) && println("bound tightening presolve width tolerance = ", Alp.get_option(m, :presolve_bt)_width_tol)
-# Alp.get_option(m, :presolve_bt) && println("bound tightening presolve output tolerance = ", Alp.get_option(m, :presolve_bt)_output_tol)
-# Alp.get_option(m, :presolve_bt) && println("bound tightening presolve relaxation = ", Alp.get_option(m, :presolve_bt)_relax)
-# Alp.get_option(m, :presolve_bt) && println("bound tightening presolve mip regulation time = ", Alp.get_option(m, :presolve_bt)_mip_time_limit)
+# println("  Maximum solution time = ", get_option(m, :time_limit))
+# println("  Basic bound propagation = ", get_option(m, :presolve_bp))
+# println("  Conseuctive solution rejection = after ", get_option(m, :disc_consecutive_forbid), " times")
+# get_option(m, :presolve_bt) && println("bound tightening presolve algorithm = ", get_option(m, :presolve_bt)_algo)
+# get_option(m, :presolve_bt) && println("bound tightening presolve width tolerance = ", get_option(m, :presolve_bt)_width_tol)
+# get_option(m, :presolve_bt) && println("bound tightening presolve output tolerance = ", get_option(m, :presolve_bt)_output_tol)
+# get_option(m, :presolve_bt) && println("bound tightening presolve relaxation = ", get_option(m, :presolve_bt)_relax)
+# get_option(m, :presolve_bt) && println("bound tightening presolve mip regulation time = ", get_option(m, :presolve_bt)_mip_time_limit)

--- a/src/log.jl
+++ b/src/log.jl
@@ -67,7 +67,7 @@ function logging_summary(m::Optimizer)
         project = read(joinpath(dirname(@__DIR__), "Project.toml"), String)
         m_version = match(r"version \= \"(.+?)\"", project)
         println("  Alpine version = ", m_version[1])
-        if Alp.is_min_sense(m)
+        if is_min_sense(m)
             println(
                 "  Maximum iterations (lower-bounding MIPs) = ",
                 get_option(m, :max_iter),

--- a/src/main_algorithm.jl
+++ b/src/main_algorithm.jl
@@ -28,12 +28,12 @@ end
 function load!(m::Optimizer)
 
     # Initialize NLP interface
-    requested_features = Alp.features_available(m)
+    requested_features = features_available(m)
     if m.d_orig !== nothing
         MOI.initialize(m.d_orig, requested_features::Vector{Symbol})
     end
     for feat in requested_features
-        if !(feat in Alp.features_available(m))
+        if !(feat in features_available(m))
             error("Unsupported feature $feat")
         end
     end
@@ -41,11 +41,11 @@ function load!(m::Optimizer)
     # Collect objective & constraint expressions
     if m.has_nl_objective
         m.obj_expr_orig =
-            Alp.expr_isolate_const(_variable_index_to_index(MOI.objective_expr(m.d_orig))) # see in nlexpr.jl if this expr isolation has any issue
+            expr_isolate_const(_variable_index_to_index(MOI.objective_expr(m.d_orig))) # see in nlexpr.jl if this expr isolation has any issue
     elseif m.objective_function isa Nothing
         m.obj_expr_orig = Expr(:call, :+)
     else
-        m.obj_expr_orig = Alp._moi_function_to_expr(m.objective_function)
+        m.obj_expr_orig = _moi_function_to_expr(m.objective_function)
     end
 
     # Collect original variable type and build dynamic variable type space
@@ -54,7 +54,7 @@ function load!(m::Optimizer)
     m.bin_vars = [i for i in 1:m.num_var_orig if m.var_type[i] == :Bin]
 
     if !isempty(m.int_vars) || !isempty(m.bin_vars)
-        (Alp.get_option(m, :minlp_solver) === nothing) && (error(
+        (get_option(m, :minlp_solver) === nothing) && (error(
             "No MINLP local solver specified; use option 'minlp_solver' to specify a MINLP local solver",
         ))
     end
@@ -95,51 +95,51 @@ function load!(m::Optimizer)
     isa(m.obj_expr_orig, Number) && (m.obj_structure = :constant)
 
     # Populate data to create the bounding MIP model
-    Alp.recategorize_var(m)             # Initial round of variable re-categorization
+    recategorize_var(m)             # Initial round of variable re-categorization
 
     :Int in m.var_type_orig && error(
         "Alpine does not support MINLPs with generic integer (non-binary) variables yet!",
     )
 
     # Solver-dependent detection
-    Alp._fetch_mip_solver_identifier(m)
-    Alp._fetch_nlp_solver_identifier(m)
-    Alp._fetch_minlp_solver_identifier(m)
+    _fetch_mip_solver_identifier(m)
+    _fetch_nlp_solver_identifier(m)
+    _fetch_minlp_solver_identifier(m)
 
     # Main Algorithmic Initialization
-    Alp.process_expr(m)                         # Compact process of every expression
-    Alp.init_tight_bound(m)                     # Initialize bounds for algorithmic processes
-    Alp.resolve_var_bounds(m)                   # resolve lifted var bounds
-    Alp.pick_disc_vars(m)                       # Picking variables to be discretized
-    Alp.init_disc(m)                            # Initialize discretization dictionaries
+    process_expr(m)                         # Compact process of every expression
+    init_tight_bound(m)                     # Initialize bounds for algorithmic processes
+    resolve_var_bounds(m)                   # resolve lifted var bounds
+    pick_disc_vars(m)                       # Picking variables to be discretized
+    init_disc(m)                            # Initialize discretization dictionaries
 
     # Turn-on bt presolve if variables are not discrete
     if isempty(m.int_vars) &&
        length(m.bin_vars) <= 50 &&
        m.num_var_orig <= 10000 &&
        length(m.candidate_disc_vars) <= 300 &&
-       Alp.get_option(m, :presolve_bt) == nothing
-        Alp.set_option(m, :presolve_bt, true)
+       get_option(m, :presolve_bt) == nothing
+        set_option(m, :presolve_bt, true)
         println("Automatically turning on bound-tightening presolve")
-    elseif Alp.get_option(m, :presolve_bt) == nothing  # If no use indication
-        Alp.set_option(m, :presolve_bt, false)
+    elseif get_option(m, :presolve_bt) == nothing  # If no use indication
+        set_option(m, :presolve_bt, false)
     end
 
     if length(m.bin_vars) > 200 || m.num_var_orig > 2000
         println(
             "Automatically turning OFF 'partition_scaling_factor_branch' due to the size of the problem",
         )
-        Alp.set_option(m, :partition_scaling_factor_branch, false)
+        set_option(m, :partition_scaling_factor_branch, false)
     end
 
     # Initialize the solution pool
-    m.bound_sol_pool = Alp.initialize_solution_pool(m, 0)  # Initialize the solution pool
+    m.bound_sol_pool = initialize_solution_pool(m, 0)  # Initialize the solution pool
 
     # Check if any illegal term exist in the warm-solution
     any(isnan, m.best_sol) && (m.best_sol = zeros(length(m.best_sol)))
 
     # Initialize log
-    Alp.logging_summary(m)
+    logging_summary(m)
 
     return
 end
@@ -148,23 +148,23 @@ end
    High-level Function
 """
 function MOI.optimize!(m::Optimizer)
-    Alp.load!(m)
+    load!(m)
     if getproperty(m, :presolve_infeasible)
-        Alp.summary_status(m)
+        summary_status(m)
         return
     end
 
-    Alp.presolve(m)
+    presolve(m)
 
-    if !Alp.check_exit(m) && Alp.get_option(m, :apply_partitioning)
-        Alp.global_solve(m)
-        Alp.get_option(m, :log_level) > 0 && Alp.logging_row_entry(m, finish_entry = true)
+    if !check_exit(m) && get_option(m, :apply_partitioning)
+        global_solve(m)
+        get_option(m, :log_level) > 0 && logging_row_entry(m, finish_entry = true)
         println(
             "====================================================================================================",
         )
     end
 
-    Alp.summary_status(m)
+    summary_status(m)
 
     return
 end
@@ -179,19 +179,19 @@ Each [`local_solve`](@ref) provides an incumbent feasible solution. The algorith
 
 """
 function global_solve(m::Optimizer)
-    Alp.get_option(m, :log_level) > 0 && Alp.logging_head(m)
-    Alp.get_option(m, :presolve_track_time) || Alp.reset_timer(m)
-    while !Alp.check_exit(m)
+    get_option(m, :log_level) > 0 && logging_head(m)
+    get_option(m, :presolve_track_time) || reset_timer(m)
+    while !check_exit(m)
         m.logs[:n_iter] += 1
-        Alp.create_bounding_mip(m)                  # Build the relaxation model
-        Alp.bounding_solve(m)                       # Solve the relaxation model
-        Alp.update_opt_gap(m)                       # Update optimality gap
-        Alp.check_exit(m) && break                  # Feasibility check
-        Alp.get_option(m, :log_level) > 0 && Alp.logging_row_entry(m)  # Logging
-        Alp.local_solve(m)                          # Solve local model for feasible solution
-        Alp.update_opt_gap(m)                       # Update optimality gap
-        Alp.check_exit(m) && break                  # Detect optimality termination
-        Alp.algorithm_automation(m)                 # Automated adjustments
+        create_bounding_mip(m)                  # Build the relaxation model
+        bounding_solve(m)                       # Solve the relaxation model
+        update_opt_gap(m)                       # Update optimality gap
+        check_exit(m) && break                  # Feasibility check
+        get_option(m, :log_level) > 0 && logging_row_entry(m)  # Logging
+        local_solve(m)                          # Solve local model for feasible solution
+        update_opt_gap(m)                       # Update optimality gap
+        check_exit(m) && break                  # Detect optimality termination
+        algorithm_automation(m)                 # Automated adjustments
     end
 
     return
@@ -202,11 +202,11 @@ end
 """
 function presolve(m::Optimizer)
     start_presolve = time()
-    Alp.get_option(m, :log_level) > 0 &&
+    get_option(m, :log_level) > 0 &&
         printstyled("PRESOLVE \n", color = :cyan, bold = true)
-    Alp.get_option(m, :log_level) > 0 && println("  Doing local search")
+    get_option(m, :log_level) > 0 && println("  Doing local search")
 
-    if Alp.get_option(m, :use_start_as_incumbent)
+    if get_option(m, :use_start_as_incumbent)
         # Check for bound feasibility of the warm start value
         if !(m.l_var_orig <= m.warm_start_value <= m.u_var_orig)
             error(
@@ -222,44 +222,44 @@ function presolve(m::Optimizer)
                 m.objective_function,
             )
         end
-        Alp.update_incumbent(m, obj_warmval, m.warm_start_value)
+        update_incumbent(m, obj_warmval, m.warm_start_value)
         m.status[:local_solve] = MOI.OPTIMIZE_NOT_CALLED
-        Alp.get_option(m, :log_level) > 0 && println(
+        get_option(m, :log_level) > 0 && println(
             "  Using warm starting point as a local incumbent solution with value $(round(m.best_obj, digits=4))",
         )
     else
-        Alp.local_solve(m, presolve = true)
+        local_solve(m, presolve = true)
     end
 
     # Solver status
     if m.status[:local_solve] in union(STATUS_OPT, STATUS_LIMIT, STATUS_WARM_START)
-        if !Alp.get_option(m, :use_start_as_incumbent)
-            Alp.get_option(m, :log_level) > 0 && println(
+        if !get_option(m, :use_start_as_incumbent)
+            get_option(m, :log_level) > 0 && println(
                 "  Local solver returns a feasible point with value $(round(m.best_obj, digits=4))",
             )
         end
-        Alp.bound_tightening_wrapper(m, use_bound = true)    # performs bound-tightening with the local solve objective value
-        Alp.get_option(m, :presolve_bt) && Alp.init_disc(m)            # Re-initialize discretization dictionary on tight bounds
-        Alp.get_option(m, :partition_scaling_factor_branch) && (Alp.set_option(
+        bound_tightening_wrapper(m, use_bound = true)    # performs bound-tightening with the local solve objective value
+        get_option(m, :presolve_bt) && init_disc(m)            # Re-initialize discretization dictionary on tight bounds
+        get_option(m, :partition_scaling_factor_branch) && (set_option(
             m,
             :partition_scaling_factor,
-            Alp.update_partition_scaling_factor(m, true),
+            update_partition_scaling_factor(m, true),
         ))
 
     elseif m.status[:local_solve] in STATUS_INF
-        (Alp.get_option(m, :log_level) > 0) &&
+        (get_option(m, :log_level) > 0) &&
             println("  Bound tightening without objective bounds (OBBT)")
-        Alp.bound_tightening_wrapper(m, use_bound = false)                      # do bound tightening without objective value
-        (Alp.get_option(m, :partition_scaling_factor_branch)) && (Alp.set_option(
+        bound_tightening_wrapper(m, use_bound = false)                      # do bound tightening without objective value
+        (get_option(m, :partition_scaling_factor_branch)) && (set_option(
             m,
             :partition_scaling_factor,
-            Alp.update_partition_scaling_factor(m, true),
+            update_partition_scaling_factor(m, true),
         ))
-        Alp.get_option(m, :presolve_bt) && Alp.init_disc(m)
+        get_option(m, :presolve_bt) && init_disc(m)
 
     elseif m.status[:local_solve] == MOI.INVALID_MODEL
         @warn " Warning: Presolve ends with local solver yielding $(m.status[:local_solve]). \n This may come from Ipopt's `:Not_Enough_Degrees_Of_Freedom`."
-    elseif !Alp.get_option(m, :use_start_as_incumbent)
+    elseif !get_option(m, :use_start_as_incumbent)
         @warn " Warning: Presolve ends with local solver yielding $(m.status[:local_solve])."
     end
 
@@ -268,12 +268,12 @@ function presolve(m::Optimizer)
     m.logs[:total_time] = m.logs[:presolve_time]
     m.logs[:time_left] -= m.logs[:presolve_time]
 
-    if Alp.get_option(m, :presolve_bt)
-        (Alp.get_option(m, :log_level) > 0) && println(
+    if get_option(m, :presolve_bt)
+        (get_option(m, :log_level) > 0) && println(
             "  Post-presolve optimality gap: $(round(m.presolve_best_rel_gap; digits = 3))%",
         )
     end
-    (Alp.get_option(m, :log_level) > 0) &&
+    (get_option(m, :log_level) > 0) &&
         println("  Completed presolve in $(round.(m.logs[:total_time]; digits = 2))s")
 
     return
@@ -285,16 +285,12 @@ end
 function algorithm_automation(m::Optimizer)
 
     # Only if a feasible solution is detected
-    if (Alp.get_option(m, :disc_var_pick) == 3) && m.detected_incumbent
-        Alp.update_disc_cont_var(m)
+    if (get_option(m, :disc_var_pick) == 3) && m.detected_incumbent
+        update_disc_cont_var(m)
     end
 
-    if Alp.get_option(m, :partition_scaling_factor_branch)
-        Alp.set_option(
-            m,
-            :partition_scaling_factor,
-            Alp.update_partition_scaling_factor(m, true),
-        )    # Only perform for a maximum three times
+    if get_option(m, :partition_scaling_factor_branch)
+        set_option(m, :partition_scaling_factor, update_partition_scaling_factor(m, true))    # Only perform for a maximum three times
     end
 
     return
@@ -306,7 +302,7 @@ end
 function check_exit(m::Optimizer)
 
     # constant objective with feasible local solve check
-    if Alp.expr_isconst(m.obj_expr_orig) &&
+    if expr_isconst(m.obj_expr_orig) &&
        (m.status[:local_solve] == MOI.OPTIMAL || m.status == MOI.LOCALLY_SOLVED)
         # m.best_bound = eval(m.obj_expr_orig)
         m.best_bound = m.obj_expr_orig
@@ -325,15 +321,15 @@ function check_exit(m::Optimizer)
     m.status[:bounding_solve] == MOI.DUAL_INFEASIBLE && return true
 
     # Optimality check
-    if m.best_rel_gap <= Alp.get_option(m, :rel_gap)
+    if m.best_rel_gap <= get_option(m, :rel_gap)
         m.detected_bound = true
         return true
     end
-    m.logs[:n_iter] >= Alp.get_option(m, :max_iter) && return true
-    m.best_abs_gap <= Alp.get_option(m, :abs_gap) && return true
+    m.logs[:n_iter] >= get_option(m, :max_iter) && return true
+    m.best_abs_gap <= get_option(m, :abs_gap) && return true
 
     # User-limits check
-    m.logs[:time_left] < Alp.get_option(m, :tol) && return true
+    m.logs[:time_left] < get_option(m, :tol) && return true
 
     return false
 end
@@ -341,7 +337,7 @@ end
 function load_nonlinear_model(m::Optimizer, model::MOI.ModelLike, l_var, u_var)
     x = MOI.add_variables(model, m.num_var_orig)
     for i in eachindex(x)
-        set = Alp._bound_set(l_var[i], u_var[i])
+        set = _bound_set(l_var[i], u_var[i])
         if set !== nothing
             MOI.add_constraint(model, x[i], set)
         end
@@ -380,7 +376,7 @@ function set_variable_type(model::MOI.ModelLike, xs, variable_types)
 end
 
 """
-   Alp.local_solve(m::Optimizer, presolve::Bool=false)
+   local_solve(m::Optimizer, presolve::Bool=false)
 
 Perform a local NLP or MINLP solve to obtain a feasible solution.
 The `presolve` option is set to `true` when the function is invoked in [`presolve`](@ref).
@@ -393,34 +389,28 @@ function local_solve(m::Optimizer; presolve = false)
     var_type_screener = [i for i in m.var_type_orig if i in [:Bin, :Int]]
 
     if presolve
-        if !isempty(var_type_screener) && Alp.get_option(m, :minlp_solver) !== nothing
-            local_solve_model = MOI.instantiate(
-                Alp.get_option(m, :minlp_solver),
-                with_bridge_type = Float64,
-            )
+        if !isempty(var_type_screener) && get_option(m, :minlp_solver) !== nothing
+            local_solve_model =
+                MOI.instantiate(get_option(m, :minlp_solver), with_bridge_type = Float64)
         elseif !isempty(var_type_screener)
-            local_solve_model = MOI.instantiate(
-                Alp.get_option(m, :nlp_solver),
-                with_bridge_type = Float64,
-            )
+            local_solve_model =
+                MOI.instantiate(get_option(m, :nlp_solver), with_bridge_type = Float64)
         else
-            local_solve_model = MOI.instantiate(
-                Alp.get_option(m, :nlp_solver),
-                with_bridge_type = Float64,
-            )
+            local_solve_model =
+                MOI.instantiate(get_option(m, :nlp_solver), with_bridge_type = Float64)
         end
     else
         local_solve_model =
-            MOI.instantiate(Alp.get_option(m, :nlp_solver), with_bridge_type = Float64)
+            MOI.instantiate(get_option(m, :nlp_solver), with_bridge_type = Float64)
     end
 
     if presolve == false
-        l_var, u_var = Alp.fix_domains(m)
+        l_var, u_var = fix_domains(m)
     else
         l_var, u_var = m.l_var_tight[1:m.num_var_orig], m.u_var_tight[1:m.num_var_orig]
     end
 
-    x = Alp.load_nonlinear_model(m, local_solve_model, l_var, u_var)
+    x = load_nonlinear_model(m, local_solve_model, l_var, u_var)
     if m.d_orig !== nothing
         MOI.initialize(m.d_orig, [:Grad, :Jac, :Hess, :HessVec, :ExprGraph]) # Safety scheme for sub-solvers re-initializing the NLPEvaluator
     end
@@ -436,11 +426,11 @@ function local_solve(m::Optimizer; presolve = false)
 
     # The only case when MINLP solver is actually used
     if presolve && !isempty(var_type_screener)
-        if Alp.get_option(m, :minlp_solver) === nothing
+        if get_option(m, :minlp_solver) === nothing
             error("Provide a valid MINLP solver")
             # do_heuristic = true
         else
-            Alp.set_variable_type(local_solve_model, x, m.var_type_orig)
+            set_variable_type(local_solve_model, x, m.var_type_orig)
         end
     end
 
@@ -454,7 +444,7 @@ function local_solve(m::Optimizer; presolve = false)
 
     cputime_local_solve = time() - start_local_solve
     m.logs[:total_time] += cputime_local_solve
-    m.logs[:time_left] = max(0.0, Alp.get_option(m, :time_limit) - m.logs[:total_time])
+    m.logs[:time_left] = max(0.0, get_option(m, :time_limit) - m.logs[:total_time])
 
     # if do_heuristic
     # m.status[:local_solve] = heu_basic_rounding(m, MOI.get(local_solve_model, MOI.VariablePrimal(), x))
@@ -480,12 +470,12 @@ function local_solve(m::Optimizer; presolve = false)
         end
 
         @assert length(candidate_sol) == length(sol_temp)
-        Alp.update_incumbent(m, candidate_obj, candidate_sol)
+        update_incumbent(m, candidate_obj, candidate_sol)
         m.status[:local_solve] = local_nlp_status
         return
 
         # elseif local_nlp_status in STATUS_INF
-        #     Alp.heu_pool_multistart(m) == MOI.LOCALLY_SOLVED && return
+        #     heu_pool_multistart(m) == MOI.LOCALLY_SOLVED && return
         #     push!(m.logs[:obj], "INF")
         #     m.status[:local_solve] = MOI.LOCALLY_INFEASIBLE
         #     return
@@ -515,7 +505,7 @@ function local_solve(m::Optimizer; presolve = false)
 end
 
 """
-   Alp.bounding_solve(m::Optimizer; kwargs...)
+   bounding_solve(m::Optimizer; kwargs...)
 
 This step usually solves a convex MILP/MIQCP/MIQCQP problem for lower bounding the given minimization problem.
 It solves the problem built upon a piecewise convexification based on the discretization sictionary of some variables.
@@ -525,7 +515,7 @@ function bounding_solve(m::Optimizer)
     convertor = Dict(MOI.MAX_SENSE => :<, MOI.MIN_SENSE => :>)
 
     # Updates time metric and the termination bounds
-    Alp.set_mip_time_limit(m)
+    set_mip_time_limit(m)
     # update_boundstop_options(m)
 
     # ================= Solve Start ================ #
@@ -533,7 +523,7 @@ function bounding_solve(m::Optimizer)
     JuMP.optimize!(m.model_mip)
     status = JuMP.termination_status(m.model_mip)
     m.logs[:total_time] += time() - start_bounding_solve
-    m.logs[:time_left] = max(0.0, Alp.get_option(m, :time_limit) - m.logs[:total_time])
+    m.logs[:time_left] = max(0.0, get_option(m, :time_limit) - m.logs[:total_time])
     # ================= Solve End ================ #
 
     if status in STATUS_OPT || status in STATUS_LIMIT
@@ -546,11 +536,11 @@ function bounding_solve(m::Optimizer)
         ]
 
         # Experimental code
-        Alp.measure_relaxed_deviation(m, sol = candidate_bound_sol)
-        if Alp.get_option(m, :disc_consecutive_forbid) > 0
+        measure_relaxed_deviation(m, sol = candidate_bound_sol)
+        if get_option(m, :disc_consecutive_forbid) > 0
             m.bound_sol_history[mod(
                 m.logs[:n_iter] - 1,
-                Alp.get_option(m, :disc_consecutive_forbid),
+                get_option(m, :disc_consecutive_forbid),
             )+1] = copy(candidate_bound_sol) # Requires proper offseting
         end
         push!(m.logs[:bound], candidate_bound)
@@ -590,17 +580,17 @@ This function helps pick the variables for discretization. The method chosen dep
 In case when `indices::Int` is provided, the method is chosen as built-in method. Currently,
 there are two built-in options for users as follows:
 
-* `max_cover (Alp.get_option(m, :disc_var_pick)=0, default)`: pick all variables involved in the non-linear term for discretization
-* `min_vertex_cover (Alp.get_option(m, :disc_var_pick)=1)`: pick a minimum vertex cover for variables involved in non-linear terms so that each non-linear term is at least convexified
+* `max_cover (get_option(m, :disc_var_pick)=0, default)`: pick all variables involved in the non-linear term for discretization
+* `min_vertex_cover (get_option(m, :disc_var_pick)=1)`: pick a minimum vertex cover for variables involved in non-linear terms so that each non-linear term is at least convexified
 
-For advanced usage, `Alp.get_option(m, :disc_var_pick)` allows `::Function` inputs. User can provide his/her own function to choose the variables for discretization.
+For advanced usage, `get_option(m, :disc_var_pick)` allows `::Function` inputs. User can provide his/her own function to choose the variables for discretization.
 
 """
 function pick_disc_vars(m::Optimizer)
-    disc_var_pick = Alp.get_option(m, :disc_var_pick)
+    disc_var_pick = get_option(m, :disc_var_pick)
 
     if isa(disc_var_pick, Function)
-        # eval(Alp.get_option(m, :disc_var_pick))(m)
+        # eval(get_option(m, :disc_var_pick))(m)
         disc_var_pick(m)
         length(m.disc_vars) == 0 &&
             length(m.nonconvex_terms) > 0 &&
@@ -609,15 +599,15 @@ function pick_disc_vars(m::Optimizer)
             )
     elseif isa(disc_var_pick, Int)
         if disc_var_pick == 0
-            Alp.get_candidate_disc_vars(m)
+            get_candidate_disc_vars(m)
         elseif disc_var_pick == 1
-            Alp.min_vertex_cover(m)
+            min_vertex_cover(m)
         elseif disc_var_pick == 2
-            (length(m.candidate_disc_vars) > 15) ? Alp.min_vertex_cover(m) :
-            Alp.get_candidate_disc_vars(m)
+            (length(m.candidate_disc_vars) > 15) ? min_vertex_cover(m) :
+            get_candidate_disc_vars(m)
         elseif disc_var_pick == 3 # Initial
-            (length(m.candidate_disc_vars) > 15) ? Alp.min_vertex_cover(m) :
-            Alp.get_candidate_disc_vars(m)
+            (length(m.candidate_disc_vars) > 15) ? min_vertex_cover(m) :
+            get_candidate_disc_vars(m)
         else
             error(
                 "Unsupported default indicator for picking variables for discretization",

--- a/src/multilinear.jl
+++ b/src/multilinear.jl
@@ -13,26 +13,26 @@ function amp_post_convhull(m::Optimizer; kwargs...)
         nl_type = m.nonconvex_terms[k][:nonlinear_type]
         if ((nl_type == :MULTILINEAR) || (nl_type == :BILINEAR)) &&
            (m.nonconvex_terms[k][:convexified] == false)
-            λ, α = Alp.amp_convexify_multilinear(m, k, λ, α, d)
+            λ, α = amp_convexify_multilinear(m, k, λ, α, d)
             contains_multilinear = true
         elseif nl_type == :MONOMIAL && !m.nonconvex_terms[k][:convexified]
-            λ, α = Alp.amp_convexify_quadratic_univariate(m, k, λ, α, d)
+            λ, α = amp_convexify_quadratic_univariate(m, k, λ, α, d)
         elseif nl_type == :BINLIN && !m.nonconvex_terms[k][:convexified]
-            β = Alp.amp_convexify_binlin(m, k, β)
+            β = amp_convexify_binlin(m, k, β)
         elseif nl_type == :BINPROD && !m.nonconvex_terms[k][:convexified]
-            β = Alp.amp_convexify_multilinear_binary(m, k, β)
+            β = amp_convexify_multilinear_binary(m, k, β)
         end
     end
 
     # Add lambda linking constraints
     if m.options.linking_constraints && contains_multilinear
-        Alp._add_multilinear_linking_constraints(m, λ)
+        _add_multilinear_linking_constraints(m, λ)
     end
 
     # Code for warm starting bounding MIP iterations
-    Alp.get_option(m, :convhull_warmstart) &&
+    get_option(m, :convhull_warmstart) &&
         !isempty(m.best_bound_sol) &&
-        Alp.amp_warmstart_α(m, α)
+        amp_warmstart_α(m, α)
 
     return
 end
@@ -46,9 +46,9 @@ function amp_convexify_multilinear(
 )
     m.nonconvex_terms[k][:convexified] = true  # Bookeeping the convexified terms
 
-    ml_indices, dim, extreme_point_cnt = Alp.amp_convhull_prepare(m, discretization, k)   # convert key to easy read mode
-    λ = Alp.amp_convhull_λ(m, k, ml_indices, λ, extreme_point_cnt, dim)
-    λ = Alp.populate_convhull_extreme_values(
+    ml_indices, dim, extreme_point_cnt = amp_convhull_prepare(m, discretization, k)   # convert key to easy read mode
+    λ = amp_convhull_λ(m, k, ml_indices, λ, extreme_point_cnt, dim)
+    λ = populate_convhull_extreme_values(
         m,
         discretization,
         ml_indices,
@@ -56,16 +56,8 @@ function amp_convexify_multilinear(
         dim,
         ones(Int, length(dim)),
     )
-    α = Alp.amp_convhull_α(m, ml_indices, α, dim, discretization)
-    Alp.amp_post_convhull_constrs(
-        m,
-        λ,
-        α,
-        ml_indices,
-        dim,
-        extreme_point_cnt,
-        discretization,
-    )
+    α = amp_convhull_α(m, ml_indices, α, dim, discretization)
+    amp_post_convhull_constrs(m, λ, α, ml_indices, dim, extreme_point_cnt, discretization)
 
     return λ, α
 end
@@ -80,11 +72,11 @@ function amp_convexify_quadratic_univariate(
     m.nonconvex_terms[k][:convexified] = true  # Bookeeping the convexified terms
 
     monomial_index, dim, extreme_point_cnt =
-        Alp.amp_convhull_prepare(m, discretization, k, monomial = true)
-    λ = Alp.amp_convhull_λ(m, k, monomial_index, λ, extreme_point_cnt, dim)
-    λ = Alp.populate_convhull_extreme_values(m, discretization, monomial_index, λ, 2)
-    α = Alp.amp_convhull_α(m, [monomial_index], α, dim, discretization)
-    Alp.amp_post_convhull_constrs(m, λ, α, monomial_index, discretization)
+        amp_convhull_prepare(m, discretization, k, monomial = true)
+    λ = amp_convhull_λ(m, k, monomial_index, λ, extreme_point_cnt, dim)
+    λ = populate_convhull_extreme_values(m, discretization, monomial_index, λ, 2)
+    α = amp_convhull_α(m, [monomial_index], α, dim, discretization)
+    amp_post_convhull_constrs(m, λ, α, monomial_index, discretization)
 
     return λ, α
 end
@@ -110,7 +102,7 @@ function amp_convexify_binlin(m::Optimizer, k::Any, β::Dict)
     bin_idx = bin_idx[1]
     cont_idx = cont_idx[1]
 
-    Alp.relaxation_bilinear(
+    relaxation_bilinear(
         m.model_mip,
         _index_to_variable_ref(m.model_mip, lift_idx),
         _index_to_variable_ref(m.model_mip, bin_idx),
@@ -138,7 +130,7 @@ function amp_convexify_multilinear_binary(m::Optimizer, k::Any, β::Dict)
     x = [_index_to_variable_ref(m.model_mip, i) for i in m.nonconvex_terms[k][:var_idxs]]
 
     if length(x) >= 1
-        Alp.relaxation_multilinear_binary(m.model_mip, z, x)
+        relaxation_multilinear_binary(m.model_mip, z, x)
     end
 
     return β
@@ -255,7 +247,7 @@ function populate_convhull_extreme_values(
     else
         for i in 1:dim[level]
             locator[level] = i
-            λ = Alp.populate_convhull_extreme_values(
+            λ = populate_convhull_extreme_values(
                 m,
                 discretization,
                 indices,
@@ -284,7 +276,7 @@ function amp_convhull_α(
         if !(i in keys(α))
             lambda_cnt = length(discretization[i])
             partition_cnt = length(discretization[i]) - 1
-            if Alp.get_option(m, :convhull_ebd) && partition_cnt > 2
+            if get_option(m, :convhull_ebd) && partition_cnt > 2
                 αCnt = Int(ceil(log(2, partition_cnt)))
                 α[i] = JuMP.@variable(
                     m.model_mip,
@@ -326,7 +318,7 @@ function amp_warmstart_α(m::Optimizer, α::Dict)
 
     if m.bound_sol_pool[:cnt] >= 2 # can only warm-start the problem when pool is large enough
         ws_idx = -1
-        Alp.is_min_sense(m) ? ws_obj = Inf : ws_obj = -Inf
+        is_min_sense(m) ? ws_obj = Inf : ws_obj = -Inf
         comp_opr = Dict(MOI.MIN_SENSE => :<, MOI.MAX_SENSE => :>)
 
         # Search for the pool for incumbent warm starter
@@ -344,14 +336,14 @@ function amp_warmstart_α(m::Optimizer, α::Dict)
             for v in m.bound_sol_pool[:vars]
                 partition_cnt = length(d[v]) - 1
                 active_j =
-                    Alp.get_active_partition_idx(d, m.bound_sol_pool[:sol][ws_idx][v], v)
+                    get_active_partition_idx(d, m.bound_sol_pool[:sol][ws_idx][v], v)
                 for j in 1:partition_cnt
                     j == active_j ? JuMP.set_start_value(α[v][j], 1.0) :
                     JuMP.set_start_value(α[v][j], 0.0)
                 end
             end
             m.bound_sol_pool[:stat][ws_idx] = :Warmstarter
-            Alp.get_option(m, :log_level) > 0 && println(
+            get_option(m, :log_level) > 0 && println(
                 "!! WARM START bounding MIP using POOL SOL $(ws_idx) OBJ=$(m.bound_sol_pool[:obj][ws_idx])",
             )
         end
@@ -385,12 +377,12 @@ function amp_post_convhull_constrs(
     for (cnt, i) in enumerate(indices)
         l_cnt = length(d[i])
         if m.var_type[i] == :Cont
-            Alp.amp_post_inequalities_cont(m, d, λ, α, indices, dim, i, cnt)        # Add links between λ and α
+            amp_post_inequalities_cont(m, d, λ, α, indices, dim, i, cnt)        # Add links between λ and α
         else
             error("EXCEPTION: unexpected variable type during integer related realxation")
         end
         sliced_indices =
-            [Alp.collect_indices(λ[indices][:indices], cnt, [k], dim) for k in 1:l_cnt] # Add x = f(λ) for convex representation of x value
+            [collect_indices(λ[indices][:indices], cnt, [k], dim) for k in 1:l_cnt] # Add x = f(λ) for convex representation of x value
         JuMP.@constraint(
             m.model_mip,
             _index_to_variable_ref(m.model_mip, i) == sum(
@@ -432,11 +424,11 @@ function amp_post_convhull_constrs(
     )
 
     # Add SOS-2 Constraints with basic encoding
-    if Alp.get_option(m, :convhull_ebd) && partition_cnt > 2
-        ebd_map = Alp.embedding_map(
+    if get_option(m, :convhull_ebd) && partition_cnt > 2
+        ebd_map = embedding_map(
             lambda_cnt,
-            Alp.get_option(m, :convhull_ebd_encode),
-            Alp.get_option(m, :convhull_ebd_ibs),
+            get_option(m, :convhull_ebd_encode),
+            get_option(m, :convhull_ebd_ibs),
         )
         YCnt = Int(ebd_map[:L])
         @assert YCnt == length(α[monomial_idx])
@@ -515,24 +507,20 @@ function amp_post_inequalities_cont(
     partition_cnt = lambda_cnt - 1
 
     # Embedding formulation
-    if Alp.get_option(m, :convhull_formulation) == "sos2" &&
-       Alp.get_option(m, :convhull_ebd) &&
+    if get_option(m, :convhull_formulation) == "sos2" &&
+       get_option(m, :convhull_ebd) &&
        partition_cnt > 2
-        ebd_map = Alp.embedding_map(
+        ebd_map = embedding_map(
             lambda_cnt,
-            Alp.get_option(m, :convhull_ebd_encode),
-            Alp.get_option(m, :convhull_ebd_ibs),
+            get_option(m, :convhull_ebd_encode),
+            get_option(m, :convhull_ebd_ibs),
         )
         YCnt = Int(ebd_map[:L])
         @assert YCnt == length(α[var_ind])
         for i in 1:YCnt
-            p_sliced_indices = Alp.collect_indices(
-                λ[ml_indices][:indices],
-                cnt,
-                collect(ebd_map[i]),
-                dim,
-            )
-            n_sliced_indices = Alp.collect_indices(
+            p_sliced_indices =
+                collect_indices(λ[ml_indices][:indices], cnt, collect(ebd_map[i]), dim)
+            n_sliced_indices = collect_indices(
                 λ[ml_indices][:indices],
                 cnt,
                 collect(ebd_map[i+YCnt]),
@@ -547,7 +535,7 @@ function amp_post_inequalities_cont(
                 sum(λ[ml_indices][:vars][n_sliced_indices]) <= 1 - α[var_ind][i]
             )
         end
-        Alp.get_option(m, :convhull_ebd_link) && Alp.ebd_link_xα(
+        get_option(m, :convhull_ebd_link) && ebd_link_xα(
             m,
             α[var_ind],
             lambda_cnt,
@@ -559,9 +547,9 @@ function amp_post_inequalities_cont(
     end
 
     # SOS-2 Formulation
-    if Alp.get_option(m, :convhull_formulation) == "sos2"
+    if get_option(m, :convhull_formulation) == "sos2"
         for j in 1:lambda_cnt
-            sliced_indices = Alp.collect_indices(λ[ml_indices][:indices], cnt, [j], dim)
+            sliced_indices = collect_indices(λ[ml_indices][:indices], cnt, [j], dim)
             if (j == 1)
                 JuMP.@constraint(
                     m.model_mip,
@@ -581,10 +569,9 @@ function amp_post_inequalities_cont(
             end
         end
         return
-    elseif Alp.get_option(m, :convhull_formulation) == "facet"
+    elseif get_option(m, :convhull_formulation) == "facet"
         for j in 1:(partition_cnt-1) # Constraint cluster of α >= f(λ)
-            sliced_indices =
-                Alp.collect_indices(λ[ml_indices][:indices], cnt, [1:j;], dim)
+            sliced_indices = collect_indices(λ[ml_indices][:indices], cnt, [1:j;], dim)
             JuMP.@constraint(
                 m.model_mip,
                 sum(α[var_ind][1:j]) >= sum(λ[ml_indices][:vars][sliced_indices])
@@ -592,7 +579,7 @@ function amp_post_inequalities_cont(
         end
         for j in 1:(partition_cnt-1) # Constraint cluster of α <= f(λ)
             sliced_indices =
-                Alp.collect_indices(λ[ml_indices][:indices], cnt, [1:(j+1);], dim)
+                collect_indices(λ[ml_indices][:indices], cnt, [1:(j+1);], dim)
             JuMP.@constraint(
                 m.model_mip,
                 sum(α[var_ind][1:j]) <= sum(λ[ml_indices][:vars][sliced_indices])
@@ -625,26 +612,26 @@ end
     _add_multilinear_linking_constraints(m::Optimizer, λ::Dict)
 
 This internal function adds linking constraints between λ multipliers corresponding to multilinear terms
-that share more than two variables and are partitioned. For example, suppose we have λ[i], λ[j], and 
-λ[k] where i=(1,2,3), j=(1,2,4), and k=(1,2,5). λ[i] contains all multipliers for the extreme points 
+that share more than two variables and are partitioned. For example, suppose we have λ[i], λ[j], and
+λ[k] where i=(1,2,3), j=(1,2,4), and k=(1,2,5). λ[i] contains all multipliers for the extreme points
 in the space of (x1,x2,x3). λ[j] contains all multipliers for the extreme points in the space of (x1,x2,x4).
 λ[k] contains all multipliers for the extreme points in the space of (x1,x2,x5).
 
 Using λ[i], λ[j], or λ[k], we can express multilinear function x1*x2.
 We define a linking variable μ(1,2) that represents the value of x1*x2.
 Linking constraints are
-    μ(1,2) == convex combination expr for x1*x2 using λ[i],    
-    μ(1,2) == convex combination expr for x1*x2 using λ[j], and   
-    μ(1,2) == convex combination expr for x1*x2 using λ[k].    
+    μ(1,2) == convex combination expr for x1*x2 using λ[i],
+    μ(1,2) == convex combination expr for x1*x2 using λ[j], and
+    μ(1,2) == convex combination expr for x1*x2 using λ[k].
 
 Thus, these constraints link between λ[i], λ[j], and λ[k] variables.
 
-Reference: J. Kim, J.P. Richard, M. Tawarmalani, Piecewise Polyhedral Relaxations of Multilinear Optimization, 
+Reference: J. Kim, J.P. Richard, M. Tawarmalani, Piecewise Polyhedral Relaxations of Multilinear Optimization,
 http://www.optimization-online.org/DB_HTML/2022/07/8974.html
 """
 function _add_multilinear_linking_constraints(m::Optimizer, λ::Dict)
     if isnothing(m.linking_constraints_info)
-        m.linking_constraints_info = Alp._get_shared_multilinear_terms_info(
+        m.linking_constraints_info = _get_shared_multilinear_terms_info(
             λ,
             m.options.linking_constraints_degree_limit,
         )
@@ -684,8 +671,8 @@ end
 """
     _get_shared_multilinear_terms_info(λ, linking_constraints_degree_limit)
 
-This function checks to see if linking constraints are 
-necessary for a given vector of each multilinear terms and returns the approapriate 
+This function checks to see if linking constraints are
+necessary for a given vector of each multilinear terms and returns the approapriate
 linking constraints information.
 """
 function _get_shared_multilinear_terms_info(
@@ -700,7 +687,7 @@ function _get_shared_multilinear_terms_info(
         return (linking_constraints_info = nothing)
     end
 
-    # Limit the linking constraints to a prescribed multilinear degree 
+    # Limit the linking constraints to a prescribed multilinear degree
     if !isnothing(linking_constraints_degree_limit) &&
        (linking_constraints_degree_limit < max_degree)
         max_degree = linking_constraints_degree_limit

--- a/src/variable_bounds.jl
+++ b/src/variable_bounds.jl
@@ -104,7 +104,7 @@ x >= 5, x <= 5 or x == 5 and fetch the information to m.l_var_tight and m.u_var_
 function bound_propagation(m::Optimizer)
     exhausted = false
     infeasible = false
-    tol = Alp.get_option(m, :tol)
+    tol = get_option(m, :tol)
 
     while !exhausted
         exhausted = true
@@ -146,11 +146,11 @@ function bound_propagation(m::Optimizer)
                     if eval_l_bound > m.l_var_tight[var_idx] + tol
                         exhausted = false
                         m.l_var_tight[var_idx] = eval_l_bound
-                        (Alp.get_option(m, :log_level) > 199) && println(
+                        (get_option(m, :log_level) > 199) && println(
                             "[VAR$(var_idx)] LB $(m.l_var_tight[var_idx]) evaluated from constraint",
                         )
                     elseif eval_l_bound > m.u_var_tight[var_idx] + tol
-                        (Alp.get_option(m, :log_level) > 199) && println(
+                        (get_option(m, :log_level) > 199) && println(
                             "[VAR$(var_idx)] Infeasibility detection during bound propagation",
                         )
                         infeasible = true
@@ -160,11 +160,11 @@ function bound_propagation(m::Optimizer)
                     if eval_u_bound < m.u_var_tight[var_idx] - tol
                         exhausted = false
                         m.u_var_tight[var_idx] = eval_u_bound
-                        (Alp.get_option(m, :log_level) > 199) && println(
+                        (get_option(m, :log_level) > 199) && println(
                             "[VAR$(var_idx)] UB $(m.u_var_tight[var_idx]) evaluated from constraints",
                         )
                     elseif eval_u_bound < m.l_var_tight[var_idx] - tol
-                        (Alp.get_option(m, :log_level) > 199) && println(
+                        (get_option(m, :log_level) > 199) && println(
                             "[VAR$(var_idx)] Infeasibility detection during bound propagation",
                         )
                         infeasible = true
@@ -190,11 +190,11 @@ function bound_propagation(m::Optimizer)
                     if eval_bound > m.l_var_tight[var_idx] + tol
                         exhausted = false
                         m.l_var_tight[var_idx] = eval_bound
-                        (Alp.get_option(m, :log_level) > 199) && println(
+                        (get_option(m, :log_level) > 199) && println(
                             "[VAR$(var_idx)] LB $(m.l_var_tight[var_idx]) evaluated from constraints",
                         )
                     elseif eval_bound > m.u_var_tight[var_idx] + tol
-                        (Alp.get_option(m, :log_level) > 199) && println(
+                        (get_option(m, :log_level) > 199) && println(
                             "[VAR$(var_idx)] Infeasibility detection during bound propagation",
                         )
                         infeasible = true
@@ -219,11 +219,11 @@ function bound_propagation(m::Optimizer)
                     if eval_bound < m.u_var_tight[var_idx] - tol
                         exhausted = false
                         m.u_var_tight[var_idx] = eval_bound
-                        (Alp.get_option(m, :log_level) > 199) && println(
+                        (get_option(m, :log_level) > 199) && println(
                             "[VAR$(var_idx)] UB $(m.u_var_tight[var_idx]) evaluated from constraints",
                         )
                     elseif eval_bound < m.l_var_tight[var_idx] - tol
-                        (Alp.get_option(m, :log_level) > 199) && println(
+                        (get_option(m, :log_level) > 199) && println(
                             "[VAR$(var_idx)] Infeasibility detection during bound propagation",
                         )
                         infeasible = true
@@ -248,11 +248,11 @@ function bound_propagation(m::Optimizer)
                     if eval_bound < m.u_var_tight[var_idx] - tol
                         exhausted = false
                         m.u_var_tight[var_idx] = eval_bound
-                        (Alp.get_option(m, :log_level) > 199) && println(
+                        (get_option(m, :log_level) > 199) && println(
                             "[VAR$(var_idx)] UB $(m.u_var_tight[var_idx]) evaluated from constraints",
                         )
                     elseif eval_bound < m.l_var_tight[var_idx] - tol
-                        (Alp.get_option(m, :log_level) > 199) && println(
+                        (get_option(m, :log_level) > 199) && println(
                             "[VAR$(var_idx)] Infeasibility detection during bound propagation",
                         )
                         infeasible = true
@@ -276,11 +276,11 @@ function bound_propagation(m::Optimizer)
                     if eval_bound > m.l_var_tight[var_idx] + tol
                         exhausted = false
                         m.l_var_tight[var_idx] = eval_bound
-                        (Alp.get_option(m, :log_level) > 199) && println(
+                        (get_option(m, :log_level) > 199) && println(
                             "[VAR$(var_idx)] LB $(m.l_var_tight[var_idx]) evaluated from constraints",
                         )
                     elseif eval_bound > m.u_var_tight[var_idx] + tol
-                        (Alp.get_option(m, :log_level) > 199) && println(
+                        (get_option(m, :log_level) > 199) && println(
                             "[VAR$(var_idx)] Infeasibility detection during bound propagation",
                         )
                         infeasible = true
@@ -289,7 +289,7 @@ function bound_propagation(m::Optimizer)
                 end
             end
         end
-        (exhausted == true && Alp.get_option(m, :log_level) > 99) &&
+        (exhausted == true && get_option(m, :log_level) > 99) &&
             println("Initial constraint-based bound evaluation exhausted...")
     end
 
@@ -324,12 +324,12 @@ in known or trivial bounds information to deduce lifted variable bounds and to p
 function resolve_var_bounds(m::Optimizer)
 
     # Basic Bound propagation
-    if Alp.get_option(m, :presolve_bp)
-        setproperty!(m, :presolve_infeasible, Alp.bound_propagation(m)) # Fetch bounds from constraints
+    if get_option(m, :presolve_bp)
+        setproperty!(m, :presolve_infeasible, bound_propagation(m)) # Fetch bounds from constraints
     end
 
-    # Resolve unbounded variables in the original formulation 
-    Alp.resolve_inf_bounds(m)
+    # Resolve unbounded variables in the original formulation
+    resolve_inf_bounds(m)
 
     # Added sequential bound resolving process base on DFS process, which ensures all bounds are secured.
     # Increased complexity from linear to square but a reasonable amount
@@ -339,7 +339,7 @@ function resolve_var_bounds(m::Optimizer)
         if haskey(m.nonconvex_terms, k)
             m.nonconvex_terms[k][:bound_resolver](m, k)
         elseif haskey(m.linear_terms, k)
-            Alp.basic_linear_bounds(m, k)
+            basic_linear_bounds(m, k)
         else
             error("Found homeless term key $(k) during bound resolution.")
         end
@@ -360,23 +360,23 @@ function resolve_inf_bounds(m::Optimizer)
     for i in 1:length(m.l_var_orig)
         if m.l_var_tight[i] == -Inf
             warnuser = true
-            m.l_var_tight[i] = -Alp.get_option(m, :large_bound)
+            m.l_var_tight[i] = -get_option(m, :large_bound)
             infcount_l += 1
         end
         if m.u_var_tight[i] == Inf
             warnuser = true
-            m.u_var_tight[i] = Alp.get_option(m, :large_bound)
+            m.u_var_tight[i] = get_option(m, :large_bound)
             infcount_u += 1
         end
     end
     infcount = min(infcount_l, infcount_u)
     if infcount == 1
         warnuser && println(
-            "Warning: -/+Inf bounds detected on at least $infcount variable. Initializing with values -/+$(Alp.get_option(m, :large_bound)). This may affect global optimal values and run times.",
+            "Warning: -/+Inf bounds detected on at least $infcount variable. Initializing with values -/+$(get_option(m, :large_bound)). This may affect global optimal values and run times.",
         )
     elseif infcount > 1
         warnuser && println(
-            "Warning: -/+Inf bounds detected on at least $infcount variables. Initializing with values -/+$(Alp.get_option(m, :large_bound)). This may affect global optimal values and run times.",
+            "Warning: -/+Inf bounds detected on at least $infcount variables. Initializing with values -/+$(get_option(m, :large_bound)). This may affect global optimal values and run times.",
         )
     end
 
@@ -400,16 +400,16 @@ function resolve_var_bounds(m::Optimizer, d::Dict; kwargs...)
         if haskey(m.nonconvex_terms, k)
             nlk = k
             if m.nonconvex_terms[nlk][:nonlinear_type] in ALPINE_C_MONOMIAL
-                d = Alp.basic_monomial_bounds(m, nlk, d)
+                d = basic_monomial_bounds(m, nlk, d)
             elseif m.nonconvex_terms[nlk][:nonlinear_type] in [:BINPROD]
-                d = Alp.basic_binprod_bounds(m, nlk, d)
+                d = basic_binprod_bounds(m, nlk, d)
             elseif m.nonconvex_terms[nlk][:nonlinear_type] in [:BINLIN]
-                d = Alp.basic_binlin_bounds(m, nlk, d)
+                d = basic_binlin_bounds(m, nlk, d)
             else
                 error("EXPECTED ERROR : NEED IMPLEMENTATION")
             end
         elseif haskey(m.linear_terms, k)
-            d = Alp.basic_linear_bounds(m, k, d)
+            d = basic_linear_bounds(m, k, d)
         else
             error(
                 "Found a homeless term key $(k) during bound resolution im resolve_var_bounds.",
@@ -457,7 +457,7 @@ end
 # function resolve_closed_var_bounds(m::Optimizer; kwargs...)
 #     for var in m.candidate_disc_vars
 #         if abs(m.l_var_tight[var] - m.u_var_tight[var]) <
-#            Alp.get_option(m, :presolve_bt_width_tol)         # Closed Bound Criteria
+#            get_option(m, :presolve_bt_width_tol)         # Closed Bound Criteria
 #             deleteat!(m.disc_vars, findfirst(m.disc_vars, var)) # Clean nonconvex_terms by deleting the info
 #             m.discretization[var] = [m.l_var_tight[var], m.u_var_tight[var]]              # Clean up the discretization for basic McCormick if necessary
 #         end


### PR DESCRIPTION
I don't know what this was ever needed, but it seems like bad practice to refer to a module within a module.